### PR TITLE
Make rotx/y/z independent of Phased Array System Toolbox

### DIFF
--- a/matlab/robotics/@CoordinateFrame/setRotationMatrix.m
+++ b/matlab/robotics/@CoordinateFrame/setRotationMatrix.m
@@ -18,3 +18,45 @@ function obj = setRotationMatrix(obj,r)
     % update the homogeneous transformation matrix
     obj.computeHomogeneousTransform();
 end
+
+function R = rotx(alpha)
+%rotz  rotate around X by ALPHA
+%
+%	R = rotx(alpha)
+%
+% See also: roty, rotz
+% Author: Jake Reher: jreher@caltech.edu
+
+R = [1 0 0; ...
+     0 cos(alpha) -sin(alpha); ...
+     0 sin(alpha)  cos(alpha)];
+          
+end
+
+function R = roty(alpha)
+%roty  rotate around Y by ALPHA
+%
+%	R = roty(alpha)
+%
+% See also: rotx, rotz
+% Author: Jake Reher: jreher@caltech.edu
+
+R = [cos(alpha)  0 sin(alpha); ...
+             0   1          0; ...
+    -sin(alpha)  0 cos(alpha)];
+          
+end
+
+function R = rotz(alpha)
+%rotz  rotate around Z by ALPHA
+%
+%	R = rotz(alpha)
+%
+% See also: ROTX, ROTY, ROT, POS.
+% Author: Jake Reher: jreher@caltech.edus
+
+R = [cos(alpha) -sin(alpha) 0; ...
+     sin(alpha)  cos(alpha) 0; ...
+              0           0 1];
+
+end


### PR DESCRIPTION
The recent updates introduced the functions rotx/y/z when computing the rotation matrix for coordinate frames. These functions are specific to the Phased Array System Toolbox, which is not included in many standard licence packages. 