### PR TITLE
Have user set nominal contact reference frame in geometry struct. 

### DIFF
--- a/mathematica/Applications/RobotManipulator/RobotManipulator.m
+++ b/mathematica/Applications/RobotManipulator/RobotManipulator.m
@@ -1,3 +1,5 @@
+(* ::Package:: *)
+
 (* Wolfram Language Package *)
 
 (* :Title: RobotManipulator.m *)
@@ -43,6 +45,10 @@ ComputeCartesianPositions::usage =
 the 3-dimensional cartesian positions specified by the frames and relative offset vectors";
 
 ComputeEulerAngles::usage = 
+	"ComputeEularAngles[{frame1,offset1,rpy1},...,{frame$n,offset$n,rpy$n}] computes \
+the 3-dimensional cartesian positions specified by the frames and relative offset vectors";
+
+ComputeRelativeEulerAngles::usage = 
 	"ComputeEularAngles[{frame1,offset1,rpy1},...,{frame$n,offset$n,rpy$n}] computes \
 the 3-dimensional cartesian positions specified by the frames and relative offset vectors";
 
@@ -92,6 +98,8 @@ Begin["`Private`"]
 
 (* ::Section:: *)
 (* Private Constant *)
+
+
 I3=IdentityMatrix[3];
 Z3=ConstantArray[0,{3,3}];
 I4=IdentityMatrix[4];
@@ -106,15 +114,6 @@ grav = 9.81; (* the gravity constant*)
 
 (* ::Section:: *)
 (* Functions *)
-
-
-
-
-
-
-
-
-
 
 
 	
@@ -227,12 +226,26 @@ ComputeBodyJacobians[args__,nDof_] :=
 	
 
 ToEulerAngles[gst_,gst0_] :=
-	Block[{R, R0, Rw, yaw, roll, pitch,q0subs},
+	Block[{R, R0, Rw, yaw, roll, pitch, q0subs},
 		(* compute rigid orientation*)
 		R = Screws`RigidOrientation[gst];
 		(* compute rigid orientation with initial tool configuration (q = 0) *)
 		R0 = Screws`RigidOrientation[gst0];
 		(* compute spatial orientation *)
+		Rw = R.Transpose[R0];
+		(* compute Euler angles *)
+		yaw=ArcTan[Rw[[1,1]],Rw[[2,1]]];
+		roll=ArcTan[Rw[[3,3]],Rw[[3,2]]];
+		pitch=ArcTan[Rw[[3,3]],-Rw[[3,1]]Cos[roll]];
+		
+		Return[{roll,pitch,yaw}];
+	];
+	
+ToRelativeEulerAngles[gst_,R0_] :=
+	Block[{R, Rw, yaw, roll, pitch},
+		(* compute rigid orientation*)
+		R = Screws`RigidOrientation[gst];
+	
 		Rw = R.Transpose[R0];
 		(* compute Euler angles *)
 		yaw=ArcTan[Rw[[1,1]],Rw[[2,1]]];
@@ -268,6 +281,17 @@ ComputeEulerAngles[args__] :=
 		pos = MapThread[ToEulerAngles,{gst,gst0}];
 		
 		
+		Return[pos];
+	];
+	
+ComputeRelativeEulerAngles[args__] :=
+	Block[{pos, gst, R, R0, Rw, argList = {args}},
+		
+		(* first compute the forward kinematics *)
+		gst = ComputeForwardKinematics[args];
+		R0 = Map[#["R"] &, argList]; 		
+				
+		pos = MapThread[ToRelativeEulerAngles,{gst,R0}];
 		Return[pos];
 	];
 	

--- a/matlab/robotics/@RobotLinks/getRelativeEulerAngles.m
+++ b/matlab/robotics/@RobotLinks/getRelativeEulerAngles.m
@@ -1,0 +1,42 @@
+function ang= getRelativeEulerAngles(obj, frame, R, p)
+    % Returns the symbolic representation of the Euler angles of a
+    % rigid link.
+    %
+    % Parameters:
+    % frame: the list of coordinate frame of the point 
+    % @type cell
+    % R: ang is computed as the relative Euler angles from frame to R
+    % @type matrix
+    % p: the offset of the point from the origin of the frame 
+    % @type matrix
+    %
+    % 
+    % Return values:    
+    %  ang: the 3-dimensional Euler angles (roll,pitch,yaw) vector of the
+    %  CoM of the system @type SymExpression
+    %
+    %
+    % @note Syntax for ont point
+    %  
+    % >> getEulerAngles(obj,pf,offset)
+    %
+    % @note Syntax for multiple points (offset should be np*3 matrix)
+    % 
+    % >> getEulerAngles(obj,pfarray, offset)
+    
+    
+    % the number of points (one less than the nargin)
+    if nargin < 4
+        p = [];
+    end
+    if nargin < 3
+        R = eye(3);
+    end
+    c_str = getTwists(frame, p);
+    c_str{1}.R = R;
+        
+    ang = eval_math_fun('ComputeRelativeEulerAngles', c_str);
+    
+   
+    
+end


### PR DESCRIPTION
This definitely needs to be looked over. 

The proposed approach is to have a user specify a geometry.RefFrame, which is the nominal contact reference frame if it is different than the world frame. If this field is not specified assume identity. I then transform the contact wrench basis via the specified frame so that the correct axes are used. 

I have tested this only with Cassie's rotated feet. The h_{} positional constraint functions appear to be working. I am not sure if the manipulation of the wrench basis will adversely affect the constraint forces in the dynamic expressions though.